### PR TITLE
Disable Sonoff SNZB-SWV1C/SNZB-SWV2C water valve OTA images

### DIFF
--- a/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
+++ b/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
@@ -8,3 +8,4 @@ release_notes: |-
 
   **Changes**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon) on valves with a flow meter
+disabled: true

--- a/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
+++ b/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
@@ -8,3 +8,4 @@ release_notes: |-
 
   **Changes**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon)
+disabled: true


### PR DESCRIPTION
## Proposed change

The SNZB-SWV1C v1.1.0 image was reported as being offered to a Sonoff MINI-ZBRBS blinds controller (see #223 comments), so both water valve images are disabled until the image type collision is investigated.

This disables the images provided from these PRs:
- https://github.com/zigpy/zigpy-ota/pull/223
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/222
- https://github.com/zigpy/zigpy-ota/pull/234
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/224

These were included only in the (now pulled) zigpy-ota release [2026.8.1](https://github.com/zigpy/zigpy-ota/releases/tag/2026.8.1).