### PR TITLE
Re-enable Sonoff water valve OTA images with model name matching

### DIFF
--- a/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
+++ b/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
@@ -8,4 +8,8 @@ release_notes: |-
 
   **Changes**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon) on valves with a flow meter
-disabled: true
+model_names:
+  - SWV-ZFE
+  - SWV-ZFU
+  - SWV-ZNE
+  - SWV-ZNU

--- a/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
+++ b/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
@@ -8,4 +8,7 @@ release_notes: |-
 
   **Changes**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon)
-disabled: true
+model_names:
+  - SWV-ZF2
+  - SWV-ZF2E
+  - SWV-ZF2U


### PR DESCRIPTION
## Proposed change

This PR re-enables OTA images `SNZB-SWV1C` and `SNZB-SWV2C`:
- `1286-200C-00001100_dfdd63.ota`: now limited to models `SWV-ZFE`, `SWV-ZFU`, `SWV-ZNE`, `SWV-ZNU`
- `1286-210C-00001009_8e62f7.ota`: now limited to models `SWV-ZF2`, `SWV-ZF2E`, `SWV-ZF2U`

## Additional information

This essentially reverts the below PR and adds the needed model name matching (for all Sonoff water valves: 1ch + 2ch):
- https://github.com/zigpy/zigpy-ota/pull/241

So this re-enables the images provided in these PRs:
- https://github.com/zigpy/zigpy-ota/pull/223
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/222
- https://github.com/zigpy/zigpy-ota/pull/234
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/224

These were included only in the pulled zigpy-ota release [2026.8.1](https://github.com/zigpy/zigpy-ota/releases/tag/2026.8.1).