### PR TITLE
Expand Sonoff water valve OTA release notes with fixes

### DIFF
--- a/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
+++ b/images/sonoff/1286-200C-00001100_dfdd63.ota.yaml
@@ -6,7 +6,11 @@ pull_request: 223
 release_notes: |-
   This updates the Sonoff SNZB-SWV1C smart water valve (Hydro ONE and Hydro ONE Lite: SWV-ZFE, SWV-ZFU, SWV-ZNE, SWV-ZNU) to firmware version 1.1.0.
 
-  **Changes**
+  **Bug fixes**
+  - Fix several RTC and battery reporting issues
+  - Improve Bluetooth connection reliability by automatically disconnecting after prolonged inactivity
+
+  **New features**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon) on valves with a flow meter
 model_names:
   - SWV-ZFE

--- a/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
+++ b/images/sonoff/1286-210C-00001009_8e62f7.ota.yaml
@@ -6,7 +6,11 @@ pull_request: 234
 release_notes: |-
   This updates the Sonoff SNZB-SWV2C dual-channel smart water valve (Hydro DUO: SWV-ZF2, SWV-ZF2E, SWV-ZF2U) to firmware version 1.0.9.
 
-  **Changes**
+  **Bug fixes**
+  - Fix several RTC and battery reporting issues
+  - Improve Bluetooth connection reliability by automatically disconnecting after prolonged inactivity
+
+  **New features**
   - Add support for setting the water flow unit (liter, US gallon, or imperial gallon)
 model_names:
   - SWV-ZF2


### PR DESCRIPTION
## Proposed change

This PR adjusts the release notes for OTA images `SNZB-SWV1C` and `SNZB-SWV2C` to include more fixes:
- `1286-200C-00001100_dfdd63.ota`: model names: `SWV-ZFE`, `SWV-ZFU`, `SWV-ZNE`, `SWV-ZNU`
- `1286-210C-00001009_8e62f7.ota`: model names: `SWV-ZF2`, `SWV-ZF2E`, `SWV-ZF2U`

## Additional information

This is a follow-up to the PR that re-enabled the Sonoff water valve OTA images:
- https://github.com/zigpy/zigpy-ota/pull/248

This is thus also a follow-up to the original PRs/submissions that added these images:
- https://github.com/zigpy/zigpy-ota/pull/223
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/222
- https://github.com/zigpy/zigpy-ota/pull/234
    - Corresponding issue submission:
      https://github.com/zigpy/zigpy-ota/issues/224

## New release notes shown below

This updates the Sonoff SNZB-XXX to firmware version XXX.

**Bug fixes**
- Fix several RTC and battery reporting issues
- Improve Bluetooth connection reliability by automatically disconnecting after prolonged inactivity

**New features**
- Add support for setting the water flow unit (liter, US gallon, or imperial gallon) on valves with a flow meter
